### PR TITLE
Añadir funcionalidad de búsqueda al catálogo

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -121,7 +121,45 @@ async function fetchHTML(url, attempt = 1) {
     }
 }
 
-async function processCatalogPage(html) {
+function processCatalogPage(html, seenIds=new Set()) {
+    const metas = [];
+
+    const $ = cheerio.load(html);
+
+    $('a[href]').each((_, el) => {
+        const href  = $(el).attr('href') || '';
+        const match = href.match(/\/serie\/(\d+)$/);
+        if (!match) return;
+
+        const numId = match[1];
+        if (seenIds.has(numId)) return;
+        seenIds.add(numId);
+
+        let poster = $(el).find('img').first().attr('src') || '';
+        if (poster && !poster.startsWith('http')) poster = `${BASE_URL}${poster}`;
+
+        const raw  = $(el).text().trim();
+        const name = raw.replace(/\s+\d{4}\s+\d+\s*$/, '').trim() || ('Serie ' + numId);
+
+        if (!name) return;
+
+        metas.push({
+            id     : 'lacart_' + numId,
+            type   : 'series',
+            name,
+            poster : poster || undefined,
+        });
+    });
+    return metas;
+}
+
+// ==================== Pre-carga del catalogo completo ====================
+let catalogCache = null;
+
+async function buildFullCatalog() {
+    if (catalogCache) return catalogCache;
+
+    const firstHTML  = await fetchHTML(`${BASE_URL}/?page=1`);
     const $first     = cheerio.load(firstHTML);
     const pageNums   = [];
     $first('a[href*="?page="]').each((_, el) => {
@@ -134,9 +172,11 @@ async function processCatalogPage(html) {
     const allMetas = [];
     const seenIds  = new Set();
 
+    allMetas.push(...await processCatalogPage(firstHTML, seenIds)); //procesa firstHTML
+
     // Concurrencia reducida (3 a la vez) + pequena pausa entre lotes,
     // para no disparar limites anti-bot del sitio durante el arranque.
-    for (let i = 0; i < totalPages; i += 3) {
+    for (let i = 1; i < totalPages; i += 3) { //saltamos la primera página que ya procesamos
         const batch = [];
         for (let p = i + 1; p <= Math.min(i + 3, totalPages); p++) {
             batch.push(fetchHTML(`${BASE_URL}/?page=${p}`));
@@ -145,49 +185,11 @@ async function processCatalogPage(html) {
 
         for (const result of pages) {
             if (result.status !== 'fulfilled') continue;
-            const $ = cheerio.load(result.value);
-
-            $('a[href]').each((_, el) => {
-                const href  = $(el).attr('href') || '';
-                const match = href.match(/\/serie\/(\d+)$/);
-                if (!match) return;
-
-                const numId = match[1];
-                if (seenIds.has(numId)) return;
-                seenIds.add(numId);
-
-                let poster = $(el).find('img').first().attr('src') || '';
-                if (poster && !poster.startsWith('http')) poster = `${BASE_URL}${poster}`;
-
-                const raw  = $(el).text().trim();
-                const name = raw.replace(/\s+\d{4}\s+\d+\s*$/, '').trim() || ('Serie ' + numId);
-
-                if (!name) return;
-
-                allMetas.push({
-                    id     : 'lacart_' + numId,
-                    type   : 'series',
-                    name,
-                    poster : poster || undefined,
-                });
-            });
+            allMetas.push(...await processCatalogPage(result.value, seenIds));
         }
 
         await new Promise(r => setTimeout(r, 300));
     }
-
-    return allMetas;
-}
-
-// ==================== Pre-carga del catalogo completo ====================
-let catalogCache = null;
-
-async function buildFullCatalog() {
-    if (catalogCache) return catalogCache;
-
-    const firstHTML  = await fetchHTML(`${BASE_URL}/?page=1`);
-    
-    const allMetas = await processCatalogPage(firstHTML);
 
     catalogCache = allMetas;
     console.log('[CATALOGO] ' + allMetas.length + ' series cargadas.');

--- a/addon.js
+++ b/addon.js
@@ -121,13 +121,7 @@ async function fetchHTML(url, attempt = 1) {
     }
 }
 
-// ==================== Pre-carga del catalogo completo ====================
-let catalogCache = null;
-
-async function buildFullCatalog() {
-    if (catalogCache) return catalogCache;
-
-    const firstHTML  = await fetchHTML(`${BASE_URL}/?page=1`);
+async function processCatalogPage(html) {
     const $first     = cheerio.load(firstHTML);
     const pageNums   = [];
     $first('a[href*="?page="]').each((_, el) => {
@@ -182,9 +176,33 @@ async function buildFullCatalog() {
         await new Promise(r => setTimeout(r, 300));
     }
 
+    return allMetas;
+}
+
+// ==================== Pre-carga del catalogo completo ====================
+let catalogCache = null;
+
+async function buildFullCatalog() {
+    if (catalogCache) return catalogCache;
+
+    const firstHTML  = await fetchHTML(`${BASE_URL}/?page=1`);
+    
+    const allMetas = await processCatalogPage(firstHTML);
+
     catalogCache = allMetas;
     console.log('[CATALOGO] ' + allMetas.length + ' series cargadas.');
     return allMetas;
+}
+
+async function searchCatalog(searchTerm) {
+    searchTerm = searchTerm.trim().replaceAll(" ", "+").replaceAll(encodeURIComponent(" "), "+");
+
+    const firstHTML  = await fetchHTML(`${BASE_URL}/?Titulo=${searchTerm}`);
+    
+    const matchedMetas = await processCatalogPage(firstHTML);
+
+    console.log('[CATALOGO] ' + matchedMetas.length + ' series encontradas.');
+    return matchedMetas;
 }
 
 // ==================== Detalle de serie (nombre, poster, episodios) ====================
@@ -279,7 +297,7 @@ const builder = new addon.addonBuilder({
         type  : 'series',
         id    : 'lacart_catalogo',
         name  : 'LACartoons',
-        extra : [{ name: 'skip', isRequired: false }],
+        extra : [{ name: 'skip', isRequired: false }, { name: 'search', isRequired: false }],
     }],
     resources   : ['catalog', 'meta', 'stream'],
     idPrefixes  : ['lacart_'],
@@ -288,10 +306,14 @@ const builder = new addon.addonBuilder({
 // ==================== 1. CATALOGO ====================
 builder.defineCatalogHandler(async ({ extra }) => {
     try {
-        const skip      = parseInt((extra && extra.skip) || 0);
-        const PAGE_SIZE = 20;
-        const all       = await buildFullCatalog();
-        return { metas: all.slice(skip, skip + PAGE_SIZE) };
+        if (extra && extra.search) {
+            return { metas: await searchCatalog(extra.search) };
+        } else {
+            const skip      = parseInt((extra && extra.skip) || 0);
+            const PAGE_SIZE = 20;
+            const all       = await buildFullCatalog();
+            return { metas: all.slice(skip, skip + PAGE_SIZE) };
+        }
     } catch (e) {
         console.error('[CATALOGO ERROR]', e.message);
         return { metas: [] };


### PR DESCRIPTION
- Separado el procesamiento del catálogo a una función para reutilizarlo en la fase de "build" y la de búsqueda
- Añadido parámetro extra `search` al catálogo
- La búsqueda se gestiona con la funcionalidad propia de lacartoons.com. Se podría usar `catalogCache` y buscar manualmente, pero sería más complejo y potencialmente menos fiable

Fix #9